### PR TITLE
chore: remove upper bound to supported node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://eq8.js.org",
   "engines": {
-    "node": ">=4.5.0 <5.0.0",
+    "node": ">=4.5.0",
     "npm": ">=2.15.9 <3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Add support for the latest versions of NodeJS
