### PR TITLE
feat: npm install --save eq8-api@2.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -168,8 +168,8 @@
       }
     },
     "eq8-api": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eq8-api/-/eq8-api-1.0.1.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eq8-api/-/eq8-api-2.0.0.tgz",
       "dependencies": {
         "bloomrun": {
           "version": "2.1.3",
@@ -182,20 +182,20 @@
           }
         },
         "eq8-core": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/eq8-core/-/eq8-core-0.1.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/eq8-core/-/eq8-core-1.0.0.tgz",
           "dependencies": {
             "async": {
-              "version": "2.0.0-rc.3",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.0.0-rc.3.tgz"
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz"
             },
             "lodash": {
-              "version": "4.11.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz"
+              "version": "4.16.6",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz"
             },
             "winston": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.0.0",
@@ -216,10 +216,6 @@
                 "isstream": {
                   "version": "0.1.2",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                },
-                "pkginfo": {
-                  "version": "0.3.1",
-                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
                 },
                 "stack-trace": {
                   "version": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "body-parser": "1.15.2",
     "bufferutil": "1.2.1",
     "connect": "3.5.0",
-    "eq8-api": "1.0.1",
+    "eq8-api": "2.0.0",
     "jsonwebtoken": "6.2.0",
     "lodash": "4.13.1",
     "passport": "0.3.2",


### PR DESCRIPTION
BREAKING CHANGE: `Core#trigger` and `Core#search` has been replaced. See https://github.com/eq8/eq8-core/releases/tag/v1.0.0